### PR TITLE
Kuhn poker hot fix build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,14 +2,10 @@ all: compile
 
 
 compile:
-	rm -r build
-	mkdir build
-	cd build
-	cmake ../csrc/liars_dice -DCMAKE_LIBRARY_OUTPUT_DIRECTORY=../cfvpy
-	make -j
+	rm -r build && mkdir build && cd build && cmake ../csrc/kuhn_poker -DCMAKE_LIBRARY_OUTPUT_DIRECTORY=../cfvpy && make -j
 
 compile_slow:
-	mkdir -p build && cd build && cmake ../csrc/liars_dice -DCMAKE_LIBRARY_OUTPUT_DIRECTORY=../cfvpy && make -j2
+	mkdir -p build && cd build && cmake ../csrc/kuhn_poker -DCMAKE_LIBRARY_OUTPUT_DIRECTORY=../cfvpy && make -j2
 
 test: | compile
 	make -C build test

--- a/cfvpy/models.py
+++ b/cfvpy/models.py
@@ -65,7 +65,7 @@ def input_size(deck_size):
     
 
 def output_size(deck_size):
-    return deck_size*(deck_size-1)
+    return deck_size #deck_size*(deck_size-1)
 #def output_size(num_faces, num_dice):
 #    return num_faces ** num_dice
 

--- a/cfvpy/models.py
+++ b/cfvpy/models.py
@@ -53,20 +53,27 @@ def build_mlp(
     return nn.Sequential(*vals_net)
 
 
-def input_size(num_faces, num_dice):
-    return 1 + 1 + (2 * num_faces * num_dice + 1) + 2 * output_size(num_faces, num_dice)
+#def input_size(num_faces, num_dice):
+    #return 1 + 1 + (2 * num_faces * num_dice + 1) + 2 * output_size(num_faces, num_dice)
+def input_size(deck_size):
+    return (
+        1 + # player index
+        1 + # pot
+        2*deck_size + # PBS of each player
+        4 # actions
+    )
+    
 
-
-def output_size(num_faces, num_dice):
-    return num_faces ** num_dice
-
-def input_size(num_faces, num_dice):
-    return 1 + 1 + (2 * num_faces * num_dice + 1) + 2 * output_size(num_faces, num_dice)
+def output_size(deck_size):
+    return deck_size*(deck_size-1)
+#def output_size(num_faces, num_dice):
+#    return num_faces ** num_dice
 
 def input_size_kuhn(deck_size):
     return deck_size * (deck_size-1)
 def output_size_kuhn(deck_size):
     return deck_size * (deck_size-1)
+
 class Net2(nn.Module):
     def __init__(
         self,
@@ -111,7 +118,7 @@ class Net3(nn.Module):
     ):
         super().__init__()
 
-        n_in = input_size(num_faces, num_dice)
+        n_in = input_size(deck_size)
         self.body = build_mlp(
             n_in=n_in,
             n_hidden=n_hidden,

--- a/cfvpy/models.py
+++ b/cfvpy/models.py
@@ -59,7 +59,7 @@ def input_size(deck_size):
     return (
         1 + # player index
         1 + # pot
-        2*deck_size + # PBS of each player
+        2*output_size(deck_size) + # PBS of each player
         4 # actions
     )
     

--- a/cfvpy/models.py
+++ b/cfvpy/models.py
@@ -127,7 +127,7 @@ class Net3(nn.Module):
             dropout=dropout,
         )
         self.output = nn.Linear(
-            n_hidden if n_layers > 0 else n_in, output_size_kuhn(deck_size)
+            n_hidden if n_layers > 0 else n_in, output_size(deck_size)
         )
         # Make initial predictions closer to 0.
         with torch.no_grad():

--- a/cfvpy/selfplay.py
+++ b/cfvpy/selfplay.py
@@ -71,7 +71,7 @@ class CFVExp:
             ckpt_path,
         )
 
-        self.num_actions = cfg.env.num_dice * cfg.env.num_faces * 2 + 1
+        self.num_actions = 4#cfg.env.num_dice * cfg.env.num_faces * 2 + 1
 
         self.net = _build_model(self.device, self.cfg.env, self.cfg.model)
         if self.is_master:

--- a/csrc/kuhn_poker/gen_benchmark.cc
+++ b/csrc/kuhn_poker/gen_benchmark.cc
@@ -60,6 +60,8 @@ int main(int argc, char *argv[])
   // int num_dice = 1;
   // int num_faces = 4;
   int deck_size = 3;
+  std::pair<int, int> community_pot(1, 1);
+  std::pair<int, int> stack(10, 10);
   int fp_iters = 1024;
   int mdp_depth = 2;
   int num_threads = 10;
@@ -121,10 +123,10 @@ int main(int argc, char *argv[])
   assert(deck_size != -1);
   assert(mdp_depth != -1);
 
-  const Game game(deck_size);
+  const Game game(deck_size, community_pot, stack);
   assert(mdp_depth > 0);
   assert(!net_path.empty());
-  std::cout << "deck_size=" << deck_size < < < < "\n";
+  std::cout << "deck_size=" << deck_size << "\n";
   {
     const auto full_tree = unroll_tree(game);
     std::cout << "Tree of depth " << get_depth(full_tree) << " has "
@@ -151,6 +153,8 @@ int main(int argc, char *argv[])
 
   RecursiveSolvingParams cfg;
   cfg.deck_size = deck_size;
+  cfg.community_pot = community_pot;
+  cfg.stack = stack;
   cfg.subgame_params.num_iters = fp_iters;
   cfg.subgame_params.linear_update = true;
   cfg.subgame_params.optimistic = false;

--- a/csrc/kuhn_poker/kuhn_poker.h
+++ b/csrc/kuhn_poker/kuhn_poker.h
@@ -84,18 +84,22 @@ class Game {
   // 3 = bet
   std::pair<int,int> get_action_list(
       const PartialPublicState& state) const {
-    return state.last_action == kInitialAction || (state.starting_player == 1-state.player_id && state.last_action == 1)
-               ? std::pair<int, int>(2, 3)
-               : std::pair<int, int>(0, 1);
+	  if (!is_terminal(state)) {
+		  return state.last_action == kInitialAction || (state.starting_player == 1-state.player_id && state.last_action == 1)
+			  ? std::pair<int, int>(2, 4)
+			  : std::pair<int, int>(0, 2);
+	  } else {
+		  return std::pair<int, int>(2,2);
+	  }
   }
 
   bool is_terminal(const PartialPublicState& state) const {
-    return state.last_action <= 1 || (state.last_action == 2 && state.player_id == 1-state.starting_player);
+    return ((state.last_action == 0) || ((state.last_action == 2) && (state.player_id == 1-state.starting_player))) || state.last_action == 1;
   }
 
   PartialPublicState act(const PartialPublicState& state, Action action) const {
     const auto action_list = get_action_list(state);
-    assert(action == action_list.first || action == action_list.second);
+    assert (action == action_list.first || action == (action_list.second-1));
     PartialPublicState new_state;
     new_state.last_action = action;
     new_state.player_id = 1 - state.player_id;

--- a/csrc/kuhn_poker/recursive_eval.cc
+++ b/csrc/kuhn_poker/recursive_eval.cc
@@ -70,7 +70,7 @@ void report_game_stats(const Game &game, const TreeStrategy &strategy)
   for (size_t i = 0; i < std::min<size_t>(20, stats.node_reach.size()); ++i)
   {
     std::cout << std::setw(5) << i << " "
-              << game.state_to_string_short(full_tree[i].state) << "\t"
+              << game.state_to_string(full_tree[i].state) << "\t"
               << std::setprecision(4) << stats.node_reach[i];
     for (auto p : {0, 1})
     {
@@ -228,8 +228,11 @@ struct ParallerSampledStrategyComputor
 
 int main(int argc, char *argv[])
 {
-  int num_dice = 1;
-  int num_faces = 4;
+  //int num_dice = 1;
+  //int num_faces = 4;
+  int deck_size = 3;
+  std::pair<int, int> community_pot(1,1);
+  std::pair<int, int> stack(10, 10);
   int subgame_iters = 1024;
   int mdp_depth = -1;
   int num_repeats = -1;
@@ -247,17 +250,17 @@ int main(int argc, char *argv[])
     for (int i = 1; i < argc; i++)
     {
       std::string arg = argv[i];
-      if (arg == "--num_dice")
-      {
-        assert(i + 1 < argc);
-        num_dice = std::stoi(argv[++i]);
-      }
-      else if (arg == "--num_faces")
-      {
-        assert(i + 1 < argc);
-        num_faces = std::stoi(argv[++i]);
-      }
-      else if (arg == "--subgame_iters")
+      //if (arg == "--num_dice")
+      //{
+      //  assert(i + 1 < argc);
+      //  num_dice = std::stoi(argv[++i]);
+      //}
+      //else if (arg == "--num_faces")
+      //{
+      //  assert(i + 1 < argc);
+      //  num_faces = std::stoi(argv[++i]);
+      //}
+      if (arg == "--subgame_iters")
       {
         assert(i + 1 < argc);
         subgame_iters = std::stoi(argv[++i]);
@@ -329,11 +332,11 @@ int main(int argc, char *argv[])
       }
     }
   }
-  assert(num_dice != -1);
-  assert(num_faces != -1);
+  //assert(num_dice != -1);
+  //assert(num_faces != -1);
 
-  const Game game(num_dice, num_faces);
-  std::cout << "num_dice=" << num_dice << " num_faces=" << num_faces << "\n";
+  const Game game(deck_size, community_pot, stack);
+  std::cout << "deck_size=" << deck_size << "\n";
   const auto full_tree = unroll_tree(game);
   std::cout << "Tree of depth " << get_depth(full_tree) << " has "
             << full_tree.size() << " nodes\n";
@@ -389,8 +392,8 @@ int main(int argc, char *argv[])
     assert(mdp_depth > 0);
     std::shared_ptr<IValueNet> net =
         net_path == "zero"
-            ? liars_dice::create_zero_net(game.num_hands(), false)
-            : liars_dice::create_torchscript_net(net_path);
+            ? kuhn_poker::create_zero_net(game.num_hands(), false)
+            : kuhn_poker::create_torchscript_net(net_path);
 
     std::cout << "##############################################\n";
     std::cout << "##### Recursive solving                      #\n";
@@ -410,12 +413,12 @@ int main(int argc, char *argv[])
           {
             oracle_net_params.num_iters = eval_oracle_values_iters;
           }
-          return liars_dice::create_oracle_value_predictor(game,
+          return kuhn_poker::create_oracle_value_predictor(game,
                                                            oracle_net_params);
         }
         else
         {
-          return liars_dice::create_torchscript_net(net_path, "cpu");
+          return kuhn_poker::create_torchscript_net(net_path, "cpu");
         }
       };
 

--- a/csrc/kuhn_poker/rela/pybind.cc
+++ b/csrc/kuhn_poker/rela/pybind.cc
@@ -48,7 +48,7 @@ namespace
                                  const std::string &model_path)
     {
         py::gil_scoped_release release;
-        kuhn_poker::Game game(params.deck_size);
+        kuhn_poker::Game game(params.deck_size, params.community_pot, params.stack);
         std::shared_ptr<IValueNet> net =
             kuhn_poker::create_torchscript_net(model_path);
         const auto tree_strategy =
@@ -61,7 +61,7 @@ namespace
                                 const std::string &model_path)
     {
         py::gil_scoped_release release;
-        kuhn_poker::Game game(params.deck_size);
+        kuhn_poker::Game game(params.deck_size, params.community_pot, params.stack);
         std::shared_ptr<IValueNet> net =
             kuhn_poker::create_torchscript_net(model_path);
         const auto net_strategy =
@@ -90,7 +90,7 @@ namespace
     float compute_exploitability_no_net(kuhn_poker::RecursiveSolvingParams params)
     {
         py::gil_scoped_release release;
-        kuhn_poker::Game game(params.deck_size);
+        kuhn_poker::Game game(params.deck_size, params.community_pot, params.stack);
         auto fp = kuhn_poker::build_solver(game, game.get_initial_state(),
                                            kuhn_poker::get_initial_beliefs(game),
                                            params.subgame_params, /*net=*/nullptr);

--- a/csrc/kuhn_poker/rela/pybind.cc
+++ b/csrc/kuhn_poker/rela/pybind.cc
@@ -174,6 +174,8 @@ PYBIND11_MODULE(rela, m)
     py::class_<kuhn_poker::RecursiveSolvingParams>(m, "RecursiveSolvingParams")
         .def(py::init<>())
         .def_readwrite("deck_size", &kuhn_poker::RecursiveSolvingParams::deck_size)
+	.def_readwrite("community_pot", &kuhn_poker::RecursiveSolvingParams::community_pot)
+	.def_readwrite("stack", &kuhn_poker::RecursiveSolvingParams::stack)
         .def_readwrite("random_action_prob",
                        &kuhn_poker::RecursiveSolvingParams::random_action_prob)
         .def_readwrite("sample_leaf",

--- a/csrc/kuhn_poker/subgame_solving.cc
+++ b/csrc/kuhn_poker/subgame_solving.cc
@@ -135,7 +135,7 @@ namespace kuhn_poker
       buffer[write_index++] = static_cast<float>(state.player_id);
       buffer[write_index++] = static_cast<float>(traverser);
       // Hack: last action is the liar call.
-      assert(state.last_action != game.num_actions() - 1);  //TODO CHANGE
+      // assert(state.last_action != game.num_actions() - 1);  //TODO CHANGE
       for (Action action = 0; action < game.num_actions(); ++action)
       {
         buffer[write_index++] = static_cast<float>(action == state.last_action);

--- a/csrc/kuhn_poker/tree.h
+++ b/csrc/kuhn_poker/tree.h
@@ -38,7 +38,8 @@ namespace kuhn_poker
     int depth;
 
     //2 for kuhn poker
-    int num_children() const { return 2; }
+    int num_children() const { return children_end - children_begin; }
+    // Coulnd't this be zero depending on the state??
 
     std::vector<int> get_children() const
     {
@@ -70,6 +71,7 @@ namespace kuhn_poker
       auto &parent = nodes[node_id];
       parent.children_begin = nodes.size();
       parent.children_end = parent.children_begin + end - start;
+      //std::cout << "Begin and End of children: [" << parent.children_begin << " ," << parent.children_end << "]" << std::flush;
       for (int i = start; i < end; ++i)
       {
         auto state = game.act(parent.state, i);


### PR DESCRIPTION
# Overview
Fixing the build of kuhn poker so the python run.py file can execute in theory. This is mostly renaming variables with some modification to the the code internals that makes ReBeL incorrect (`compute_win_probability`)

Fixes #(we don’t actually have issues lol)

## Testing suite
Kinda(?). I ran this on the VM and it builds with an error in the cvfpy python files. The error there is in reference to `selfplay.py` with dice and faces. Hence I believe this should fix most (if not all) bugs.

If we have tests, I am happy to run those but I was uncertain if we actually had tests.

## Checklist

- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation (do we even have any lol)
- [X] My changes generate no new warnings
- [X] I have checked my code and corrected any misspellings
- [ ] Validated code against unit tests in project
- [ ] Added new unit tests to validate correctness of code
- [ ] Did some preliminary tests to ensure no new bugs have entered code due to a mistake